### PR TITLE
Deploy to GH Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'yarn'
+    - run: yarn install
+    - run: yarn build
+    - uses: actions/configure-pages@v4
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: build
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "js-synth",
   "version": "0.1.0",
+  "homepage": ".",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",


### PR DESCRIPTION
PR adds workflow that publishes SynthJS app to GitHub Pages. Sample result: https://platan.github.io/SynthJS/
After merging this PR similar site will be created for this repo. Example build and deploy log https://github.com/platan/SynthJS/actions/runs/7746675668. 

- change in `package.json` is required, because app is served with `/SynthJS` path - docs: https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths
- docs regarding deploying to GH Pages using GH Actions https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages